### PR TITLE
URL Cleanup

### DIFF
--- a/src/main/resources/templates/error/403.html
+++ b/src/main/resources/templates/error/403.html
@@ -15,7 +15,7 @@
   -->
 
 <!doctype html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html lang="en" xmlns:th="https://www.thymeleaf.org" xmlns:layout="https://github.com/ultraq/thymeleaf-layout-dialect" layout:decorate="~{layout}">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -15,7 +15,7 @@
   -->
 
 <!doctype html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html lang="en" xmlns:th="https://www.thymeleaf.org" xmlns:layout="https://github.com/ultraq/thymeleaf-layout-dialect" layout:decorate="~{layout}">
 <head>
     <meta charset="utf-8"/>
     <title>Add WebHook</title>

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -15,7 +15,7 @@
   -->
 
 <!doctype html>
-<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout">
+<html xmlns:th="https://www.thymeleaf.org" xmlns:layout="https://github.com/ultraq/thymeleaf-layout-dialect">
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/src/main/resources/templates/logout.html
+++ b/src/main/resources/templates/logout.html
@@ -15,7 +15,7 @@
   -->
 
 <!doctype html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<html lang="en" xmlns:th="https://www.thymeleaf.org" xmlns:layout="https://github.com/ultraq/thymeleaf-layout-dialect" layout:decorate="~{layout}">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/src/test/kotlin/io/spring/github/GithubHooksControllerTest.kt
+++ b/src/test/kotlin/io/spring/github/GithubHooksControllerTest.kt
@@ -3326,7 +3326,7 @@ class GithubHooksControllerTest {
             "ssh_url": "git@github.com:spring-projects/spring-security.git",
             "clone_url": "https://github.com/spring-projects/spring-security.git",
             "svn_url": "https://github.com/spring-projects/spring-security",
-            "homepage": "http://spring.io/spring-security",
+            "homepage": "https://spring.io/spring-security",
             "size": 33219,
             "stargazers_count": 2994,
             "watchers_count": 2994,

--- a/src/test/kotlin/io/spring/github/api/WebClientGitHubApiTest.kt
+++ b/src/test/kotlin/io/spring/github/api/WebClientGitHubApiTest.kt
@@ -115,7 +115,7 @@ class WebClientGitHubApiTest {
           ],
           "active": true,
           "config": {
-            "url": "http://example.com/webhook",
+            "url": "https://example.com/webhook",
             "content_type": "json"
           },
           "updated_at": "2011-09-06T20:39:23Z",
@@ -152,7 +152,7 @@ class WebClientGitHubApiTest {
             ],
             "active": true,
             "config": {
-              "url": "http://example.com/webhook",
+              "url": "https://example.com/webhook",
               "content_type": "json"
             },
             "updated_at": "2011-09-06T20:39:23Z",
@@ -171,7 +171,7 @@ class WebClientGitHubApiTest {
           ],
           "active": true,
           "config": {
-            "url": "http://example.com/webhook",
+            "url": "https://example.com/webhook",
             "content_type": "json"
           },
           "updated_at": "2011-09-06T20:39:23Z",
@@ -227,7 +227,7 @@ class WebClientGitHubApiTest {
           ],
           "active": true,
           "config": {
-            "url": "http://example.com/webhook",
+            "url": "https://example.com/webhook",
             "content_type": "json"
           },
           "updated_at": "2011-09-06T20:39:23Z",


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://www.ultraq.net.nz/thymeleaf/layout (302) with 4 occurrences migrated to:  
  https://github.com/ultraq/thymeleaf-layout-dialect ([https](https://www.ultraq.net.nz/thymeleaf/layout) result ConnectTimeoutException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://example.com/webhook with 4 occurrences migrated to:  
  https://example.com/webhook ([https](https://example.com/webhook) result 200).
* [ ] http://spring.io/spring-security with 1 occurrences migrated to:  
  https://spring.io/spring-security ([https](https://spring.io/spring-security) result 200).
* [ ] http://www.thymeleaf.org with 4 occurrences migrated to:  
  https://www.thymeleaf.org ([https](https://www.thymeleaf.org) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost/oauth2/authorization/github with 1 occurrences