### PR TITLE
Add `Fixes|Closes` matching for issue link, too

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,4 +55,5 @@ dependencies {
 	testImplementation("io.projectreactor:reactor-test")
 	testImplementation("org.mockito.kotlin:mockito-kotlin:4.0.0")
 	testImplementation("org.skyscreamer:jsonassert")
+	testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
 }

--- a/src/main/kotlin/io/spring/github/event/PushEvent.kt
+++ b/src/main/kotlin/io/spring/github/event/PushEvent.kt
@@ -22,6 +22,7 @@ import io.spring.github.api.RepositoryRef
 
 /**
  * @author Rob Winch
+ * @author Artem Bilan
  */
 class PushEvent(val ref : String, val repository : Repository, val pusher : Pusher, val commits : List<Commit> = listOf()) {
     fun getFixCommits() : List<Commit> {
@@ -63,7 +64,8 @@ class PushEvent(val ref : String, val repository : Repository, val pusher : Push
 
 
     data class Commit(val id : String, val message : String) {
-        val r = """.*?(Fixes|Closes):?\s+(gh-|#|https://github.com/.*/.*/issues/)(?<id>\d+)(\r?\n)*""".toRegex(setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))
+        val r = """.*?(Fixes|Closes):?\s+(gh-|#|(https://github.com/.*/.*/(issues|pull))/)(?<id>\d+)(\r?\n)*"""
+            .toRegex(setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))
 
         fun getFixIssueId() : Int? {
             return r.find(message)?.groups?.get("id")?.value?.toInt()

--- a/src/main/kotlin/io/spring/github/event/PushEvent.kt
+++ b/src/main/kotlin/io/spring/github/event/PushEvent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ class PushEvent(val ref : String, val repository : Repository, val pusher : Push
 
 
     data class Commit(val id : String, val message : String) {
-        val r = """.*?(Fixes|Closes):?\s+(gh\-|#)(?<id>\d+)(\r?\n)*""".toRegex(setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))
+        val r = """.*?(Fixes|Closes):?\s+(gh-|#|https://github.com/.*/.*/issues/)(?<id>\d+)(\r?\n)*""".toRegex(setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))
 
         fun getFixIssueId() : Int? {
             return r.find(message)?.groups?.get("id")?.value?.toInt()

--- a/src/test/kotlin/io/spring/github/event/PushEventTest.kt
+++ b/src/test/kotlin/io/spring/github/event/PushEventTest.kt
@@ -22,8 +22,10 @@ import org.junit.Test
 
 /**
  * @author Rob Winch
+ * @author Artem Bilan
  */
 class PushEventTest {
+
     @Test
     fun getFixedIssueIdsWhenOnlyFixesThenFindValue() {
         val e = pushEvent("Fixes: gh-123")
@@ -109,6 +111,12 @@ class PushEventTest {
     @Test
     fun getFixedIssueIdWhenSubjectAndIssueLinkThenFindValues() {
         val e = pushEvent("Subject\n\nFixes: https://github.com/some-org/some-project/issues/123")
+        assertThat(e.getFixCommits().map { c -> c.getFixIssueId() }).containsOnly(123)
+    }
+
+    @Test
+    fun getFixedIssueIdWhenSubjectAndPullRequestLinkThenFindValues() {
+        val e = pushEvent("Subject\n\nFixes: https://github.com/some-org/some-project/pull/123")
         assertThat(e.getFixCommits().map { c -> c.getFixIssueId() }).containsOnly(123)
     }
 

--- a/src/test/kotlin/io/spring/github/event/PushEventTest.kt
+++ b/src/test/kotlin/io/spring/github/event/PushEventTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,6 +104,12 @@ class PushEventTest {
                 "\n" +
                 "(cherry picked from commit 9837ec5)")
         assertThat(e.getFixCommits().map { c -> c.getFixIssueId() }).containsOnly(22261)
+    }
+
+    @Test
+    fun getFixedIssueIdWhenSubjectAndIssueLinkThenFindValues() {
+        val e = pushEvent("Subject\n\nFixes: https://github.com/some-org/some-project/issues/123")
+        assertThat(e.getFixCommits().map { c -> c.getFixIssueId() }).containsOnly(123)
     }
 
     fun pushEvent(commitMessage : String) : PushEvent {


### PR DESCRIPTION
The short syntax like `Fixes: #123` is nice,
but we lose a link to the target issue when we deal with commit history outside the GitHub.
For example, I use commits UI in the IntelliJ IDEA and would like to jump to the issue by clicking link from the commit message. Adding an issue link into a `Fixes|Closes` pattern would let me avoid adding extra link into commit message and this bot would still do its job.

Also add a `junit-vintage-engine` dependency to be able to run JUnit 4 test from Gradle